### PR TITLE
fix segfault when the VCF contains no records

### DIFF
--- a/artic/vcfCheck.cpp
+++ b/artic/vcfCheck.cpp
@@ -229,8 +229,10 @@ void artic::VcfChecker::Run()
         _getRecordStats();
     }
 
-    // get stats from final record
-    _getRecordStats();
+    // get stats from final record, if there was one
+    if(_numValid > 0) {
+        _getRecordStats();
+    }
 
     // write the stats to the report file
     std::ofstream outputReport;


### PR DESCRIPTION
This PR addresses https://github.com/artic-network/fieldbioinformatics/issues/88. It passes all the tests in `make test` but I haven't extensively tested it otherwise since the change is fairly straightforward.